### PR TITLE
Support composable update functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/.stack-work/
+.stack-work/
 result*
 /node_modules/
 dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .stack-work/
+dist-newstyle/
+cabal.project.local
+.ghc.environment.*
 result*
 /node_modules/
 dist

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ main = startApp App {..}
     subs   = []			  -- empty subscription list
 
 -- | Updates model, optionally introduces side effects
-updateModel :: Action -> Model -> Effect Model Action
+updateModel :: Action -> Model -> Effect Action Model
 updateModel AddOne m = noEff (m + 1)
 updateModel SubtractOne m = noEff (m - 1)
 updateModel NoOp m = noEff m

--- a/examples/compose-update/Main.hs
+++ b/examples/compose-update/Main.hs
@@ -1,0 +1,105 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TupleSections #-}
+module Main where
+
+-- This example demonstrates how you can split your update function
+-- into separate update functions for parts of your model and then
+-- combine them into a single update function operating on the whole
+-- model which combines their effects.
+
+import Control.Monad
+import Data.Monoid
+
+import Miso
+import Miso.Lens
+
+-- In this slightly contrived example, our model consists of two
+-- counters. When one of those counters is incremented, the other is
+-- decremented and the other way around.
+type Model = (Int, Int)
+
+data Action
+  = Increment
+  | Decrement
+  | NoOp
+  deriving (Show, Eq)
+
+-- We are going to use 'Lens'es in this example. Since @miso@ does not
+-- depend on a lens library we are going to define a couple of
+-- utilities ourselves. We recommend that in your own applications,
+-- you depend on a lens library such as @lens@ or @microlens@ to get
+-- these definitions.
+
+-- | You can find this under the same name in @lens@ and
+-- @microlens@. @lens@ also provides the infix operator '%%~' as a
+-- synonym for 'traverseOf'.
+--
+-- In this example we are only going to use this when applied to
+-- 'Lens' m a' and using 'Effect Action' for the @f@ type variable. In
+-- that case the specialized type signature is:
+--
+-- @traverseOf :: Functor f => Lens' m a -> (a -> Effect Action a) -> s -> Effect action s
+traverseOf :: Functor f => Lens s t a b -> (a -> f b) -> s -> f t
+traverseOf = id
+
+-- | A lens into the first element of a tuple. Both @lens@ and
+-- @microlens@ provide this under the same name.
+_1 :: Lens (a,c) (b,c) a b
+_1 f (a,c) = (,c) <$> f a
+
+-- | A lens into the second element of a tuple. Both @lens@ and
+-- @microlens@ provide this under the same name.
+_2 :: Lens (c,a) (c,b) a b
+_2 f (c,a) = (c,) <$> f a
+
+-- | Update function for the first counter in our 'Model'.
+updateFirstCounter :: Action -> Int -> Effect Action Int
+updateFirstCounter Increment m = noEff (m + 1)
+updateFirstCounter Decrement m = noEff (m - 1)
+updateFirstCounter NoOp m = noEff m
+
+-- | Update function for the second counter in our 'Model'. As we’ve
+-- mentioned before, this counter is decremented when the first
+-- counter is incremented and the other way around.
+updateSecondCounter :: Action -> Int -> Effect Action Int
+updateSecondCounter Increment m = noEff (m - 1)
+updateSecondCounter Decrement m = noEff (m + 1)
+updateSecondCounter NoOp m = noEff m
+
+-- | This is the combined update function for both counters.
+updateModel :: Action -> Model -> Effect Action Model
+updateModel act =
+  let -- We use 'traverseOf' to lift an update function for one
+      -- counter to an update function that operates on both
+      -- counters. The lifted function leaves the other counter
+      -- untouched.
+      liftedUpdateFirst :: Model -> Effect Action Model
+      liftedUpdateFirst = traverseOf _1 (updateFirstCounter act)
+      liftedUpdateSecond :: Model -> Effect Action Model
+      liftedUpdateSecond = traverseOf _2 (updateSecondCounter act)
+  in -- Since 'Effect Action' is an instance of 'Monad', we can just
+     -- use '<=<' to compose these lifted update functions.  It might
+     -- be helpful to look at the type signature of '<=<' specialized
+     -- for 'Effect Action':
+     --
+     -- @(<=<) :: (b -> Effect Action c) -> (a -> Effect Action b) -> a -> Effect Action c
+     liftedUpdateFirst <=< liftedUpdateSecond
+
+main :: IO ()
+main = startApp App { initialAction = NoOp, ..}
+  where
+    model  = (0, 0)
+    update = updateModel
+    view   = viewModel
+    events = defaultEvents
+    subs   = []
+
+viewModel :: Model -> View Action
+viewModel (x, y) =
+  div_
+    []
+    [ button_ [onClick Increment] [text "+"]
+    , text (show x <> " | " <> show y)
+    , button_ [onClick Decrement] [text "-"]
+    ]

--- a/examples/haskell-miso.org/client/Main.hs
+++ b/examples/haskell-miso.org/client/Main.hs
@@ -26,7 +26,7 @@ main = do
         either (const $ the404 m) id $
           runRoute (Proxy :: Proxy ClientRoutes) handlers m
 
-updateModel :: Action -> Model -> Effect Model Action
+updateModel :: Action -> Model -> Effect Action Model
 updateModel (HandleURI u) m = m { uri = u } <# do
   pure NoOp
 updateModel (ChangeURI u) m = m <# do

--- a/examples/mario/Main.hs
+++ b/examples/mario/Main.hs
@@ -63,7 +63,7 @@ mario = Model
     , window = (0,0)
     }
 
-updateMario :: Action -> Model -> Effect Model Action
+updateMario :: Action -> Model -> Effect Action Model
 updateMario NoOp m = noEff m
 updateMario (GetArrows arrs) m = step newModel
   where
@@ -77,7 +77,7 @@ updateMario (WindowCoords coords) m = step newModel
   where
     newModel = m { window = coords }
 
-step :: Model -> Effect Model Action
+step :: Model -> Effect Action Model
 step m@Model{..} = k <# do Time <$> now
   where
     k = m & gravity delta

--- a/examples/router/Main.hs
+++ b/examples/router/Main.hs
@@ -43,7 +43,7 @@ main = do
     view   = viewModel
 
 -- | Update your model
-updateModel :: Action -> Model -> Effect Model Action
+updateModel :: Action -> Model -> Effect Action Model
 updateModel (HandleURI u) m = m { uri = u } <# do
   pure NoOp
 updateModel (ChangeURI u) m = m <# do

--- a/examples/sse/client/Main.hs
+++ b/examples/sse/client/Main.hs
@@ -33,7 +33,7 @@ handleSseMsg (SSEMessage msg) = ServerMsg msg
 handleSseMsg SSEClose = ServerMsg "SSE connection closed"
 handleSseMsg SSEError = ServerMsg "SSE error"
 
-updateModel :: Action -> Model -> Effect Model Action
+updateModel :: Action -> Model -> Effect Action Model
 updateModel (ServerMsg msg) m = noEff (m {modelMsg = "Event received: " ++ msg})
 updateModel (HandleURI u) m = m {modelUri = u} <# pure NoOp
 updateModel (ChangeURI u) m = m <# (pushURI u >> pure NoOp)

--- a/examples/todo-mvc/Main.hs
+++ b/examples/todo-mvc/Main.hs
@@ -86,7 +86,7 @@ main = startApp App { initialAction = NoOp, ..}
     events = defaultEvents
     subs   = []
 
-updateModel :: Msg -> Model -> Effect Model Msg
+updateModel :: Msg -> Model -> Effect Msg Model
 updateModel NoOp m = noEff m
 updateModel (CurrentTime n) m =
   m <# do print n >> pure NoOp

--- a/examples/websocket/Main.hs
+++ b/examples/websocket/Main.hs
@@ -31,7 +31,7 @@ main = startApp App { initialAction = Id, ..}
     uri = URL "wss://echo.websocket.org"
     protocols = Protocols [ ]
 
-updateModel :: Action -> Model -> Effect Model Action
+updateModel :: Action -> Model -> Effect Action Model
 updateModel (HandleWebSocket (WebSocketMessage (Message m))) model
   = noEff model { received = m }
 updateModel (SendMessage msg) model = model <# do send msg >> pure Id

--- a/examples/xhr/Main.hs
+++ b/examples/xhr/Main.hs
@@ -43,7 +43,7 @@ main = do
       view   = viewModel
 
 -- | Update your model
-updateModel :: Action -> Model -> Effect Model Action
+updateModel :: Action -> Model -> Effect Action Model
 updateModel FetchGitHub m = m <# do
   SetGitHub <$> getGitHubAPIInfo
 updateModel (SetGitHub apiInfo) m =

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -14,7 +14,7 @@ main = startApp App { initialAction = SayHelloWorld, ..}
     events = defaultEvents
     subs   = []
 
-updateModel :: Action -> Model -> Effect Model Action
+updateModel :: Action -> Model -> Effect Action Model
 updateModel AddOne m = noEff (m + 1)
 updateModel SubtractOne m = noEff (m - 1)
 updateModel NoOp m = noEff m

--- a/ghcjs-src/Miso.hs
+++ b/ghcjs-src/Miso.hs
@@ -123,7 +123,7 @@ startApp app@App {..} =
 -- | Helper
 foldEffects
   :: (action -> IO ())
-  -> (action -> model -> Effect model action)
+  -> (action -> model -> Effect action model)
   -> (model, IO ()) -> action -> (model, IO ())
 foldEffects sink update = \(model, as) action ->
   case update action model of

--- a/ghcjs-src/Miso.hs
+++ b/ghcjs-src/Miso.hs
@@ -127,7 +127,6 @@ foldEffects
   -> (model, IO ()) -> action -> (model, IO ())
 foldEffects sink update = \(model, as) action ->
   case update action model of
-    NoEffect newModel -> (newModel, as)
-    Effect newModel eff -> (newModel, newAs)
+    Effect newModel effs -> (newModel, newAs)
       where
-        newAs = as >> do void . forkIO . sink =<< eff
+        newAs = as >> (mapM_ (forkIO . sink =<<) effs)

--- a/ghcjs-src/Miso/Effect.hs
+++ b/ghcjs-src/Miso/Effect.hs
@@ -23,20 +23,19 @@ import Miso.Effect.DOM
 
 -- | An effect represents the results of an update action.
 --
--- It consists of the updated model and an optional action. The action
--- is always run in a new thread so there is no risk of accidentally
+-- It consists of the updated model and a list of actions. Each action
+-- is run in a new thread so there is no risk of accidentally
 -- blocking the application.
 data Effect model action
-  = NoEffect model
-  | Effect model (IO action)
+  = Effect model [IO action]
 
--- | `NoEffect` smart constructor
+-- | Smart constructor for an 'Effect' with no actions.
 noEff :: model -> Effect model action
-noEff = NoEffect
+noEff m = Effect m []
 
--- | `Effect` smart constructor
+-- | Smart constructor for an 'Effect' with exactly one action.
 (<#) :: model -> IO action -> Effect model action
-(<#) = Effect
+(<#) m a = Effect m [a]
 
 -- | `Effect` smart constructor, flipped
 (#>) :: IO action -> model -> Effect model action

--- a/ghcjs-src/Miso/Effect.hs
+++ b/ghcjs-src/Miso/Effect.hs
@@ -26,17 +26,30 @@ import Miso.Effect.DOM
 -- It consists of the updated model and a list of actions. Each action
 -- is run in a new thread so there is no risk of accidentally
 -- blocking the application.
-data Effect model action
+data Effect action model
   = Effect model [IO action]
 
+instance Functor (Effect action) where
+  fmap f (Effect m acts) = Effect (f m) acts
+
+instance Applicative (Effect action) where
+  pure m = Effect m []
+  Effect fModel fActs <*> Effect xModel xActs = Effect (fModel xModel) (fActs ++ xActs)
+
+instance Monad (Effect action) where
+  return = pure
+  Effect m acts >>= f =
+    case f m of
+      Effect m' acts' -> Effect m' (acts ++ acts')
+
 -- | Smart constructor for an 'Effect' with no actions.
-noEff :: model -> Effect model action
+noEff :: model -> Effect action model
 noEff m = Effect m []
 
 -- | Smart constructor for an 'Effect' with exactly one action.
-(<#) :: model -> IO action -> Effect model action
+(<#) :: model -> IO action -> Effect action model
 (<#) m a = Effect m [a]
 
 -- | `Effect` smart constructor, flipped
-(#>) :: IO action -> model -> Effect model action
+(#>) :: IO action -> model -> Effect action model
 (#>) = flip (<#)

--- a/ghcjs-src/Miso/Router.hs
+++ b/ghcjs-src/Miso/Router.hs
@@ -43,6 +43,7 @@ import           Servant.API
 import           Web.HttpApiData
 
 import           Miso.Html             hiding (text)
+import           Miso.Lens
 
 -- | Router terminator.
 -- The 'HasRouter' instance for 'View' finalizes the router.
@@ -203,29 +204,6 @@ uriToLocation uri = Location
   }
 
 class HasURI m where lensURI :: Lens' m URI
-
-type Lens s t a b = forall f. Functor f => (a -> f b) -> s -> f t
-type Lens' s a = Lens s s a a
-type Getting r s a = (a -> Const r a) -> (s -> Const r s)
-
-newtype Const r a = Const { runConst :: r }
-  deriving Functor
-
-newtype Id a = Id { runId :: a }
-  deriving (Functor)
-
-instance Applicative Id where
-  pure = Id
-  Id f <*> Id x = Id (f x)
-
-get :: Getting a s a -> s -> a
-get l = \ s -> runConst (l Const s)
-
-set :: Lens s t a b -> b -> s -> t
-set l b = \ s -> runId (l (\ _ -> A.pure b) s)
-
-makeLens :: (s -> a) -> (s -> b -> t) -> Lens s t a b
-makeLens get' upd = \ f s -> upd s `fmap` f (get' s)
 
 getURI :: HasURI m => m -> URI
 getURI = get lensURI

--- a/ghcjs-src/Miso/Types.hs
+++ b/ghcjs-src/Miso/Types.hs
@@ -20,7 +20,7 @@ import           Miso.String
 data App model action = App
   { model :: model
   -- ^ initial model
-  , update :: action -> model -> Effect model action
+  , update :: action -> model -> Effect action model
   -- ^ Function to update model, optionally provide effects
   , view :: model -> View action
   -- ^ Function to draw `View`

--- a/miso.cabal
+++ b/miso.cabal
@@ -161,6 +161,7 @@ library
     Miso.Html.Element
     Miso.Html.Event
     Miso.Html.Property
+    Miso.Lens
     Miso.Event
     Miso.Event.Decoder
     Miso.Event.Types

--- a/miso.cabal
+++ b/miso.cabal
@@ -118,6 +118,20 @@ executable mario
     default-language:
       Haskell2010
 
+executable compose-update
+  main-is:
+    Main.hs
+  if !impl(ghcjs) || !flag(examples)
+    buildable: False
+  else
+    hs-source-dirs:
+      examples/compose-update
+    build-depends:
+      base < 5,
+      miso
+    default-language:
+      Haskell2010
+
 executable simple
   main-is:
     Main.hs

--- a/src/Miso/Lens.hs
+++ b/src/Miso/Lens.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE RankNTypes #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Miso.Lens
+-- Copyright   :  (C) 2016-2017 David M. Johnson
+-- License     :  BSD3-style (see the file LICENSE)
+-- Maintainer  :  David M. Johnson <djohnson.m@gmail.com>
+-- Stability   :  experimental
+-- Portability :  non-portable
+----------------------------------------------------------------------------
+module Miso.Lens
+  ( Lens
+  , Lens'
+  , Getting
+  , get
+  , set
+  , makeLens
+  ) where
+
+import Data.Functor.Identity
+import Control.Applicative
+
+type Lens s t a b = forall f. Functor f => (a -> f b) -> s -> f t
+type Lens' s a = Lens s s a a
+type Getting r s a = (a -> Const r a) -> (s -> Const r s)
+
+get :: Getting a s a -> s -> a
+get l = \ s -> getConst (l Const s)
+
+set :: Lens s t a b -> b -> s -> t
+set l b = \s -> runIdentity (l (\ _ -> pure b) s)
+
+makeLens :: (s -> a) -> (s -> b -> t) -> Lens s t a b
+makeLens get' upd = \ f s -> upd s `fmap` f (get' s)


### PR DESCRIPTION
This is an implementation of the ideas that I was trying to explain to you yesterday. I tried splitting the individual changes up into small self-contained commits so hopefully it’s easy to digest but I’ll give a quick summary anyway:
* `Effect` has been generalized to allow an arbitrary number of actions instead of just `0` and `1`. This is a breaking change but the smart constructors are unaffected so I think the actual breakage is not likely to be so bad.
* I moved the `Lens` utils to a separate module. This is not necessary but it feels cleaner. I’m completely fine with reverting this if you prefer that.
* This is the main part: I added `composeUpdate` which is the analogue of standard function composition but also takes care of combining the effects and I added `zoomUpdate` which lifts an update function into a larger model using a `Lens`. Funnily `zoomUpdate` is actually just `id` + some newtype wrapping and unwrapping :)

In general, it might also be worth considering swapping the type parameters to `Effect`. That would allow us to provide `Functor`, `Applicative` and `Monad` instances. In that case `composeUpdate` would just be `<=<`. I don’t have a strong opinion on whether that’s worth doing.

I’m opening this more as a further starting point of a discussion than something finished so please let me know what you think :)