### PR TITLE
Disable GHCJS8

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -2,7 +2,7 @@
 let
   inherit (pkgs.haskell.packages) ghcjsHEAD;
 in { miso-release = import ./default.nix { nixpkgs = pkgs; };
-     miso-ghcjs8 = ghcjsHEAD.callPackage ./miso-ghcjs.nix {};
+     # miso-ghcjs8 = ghcjsHEAD.callPackage ./miso-ghcjs.nix {};
      haskell-miso.org = import ./examples/haskell-miso.org {};
      sse-example = import ./examples/sse {};
    }


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/22369

@peti Hello ! :)

Any ideas as to when the aforementioned [patch](https://github.com/NixOS/nixpkgs/pull/22369/commits/344227bfb9dc77e18d1789336313959df8e3e9af) will hit `nixpkgs-unstable`?