### PR TITLE
Fix build with servant >= 0.10

### DIFF
--- a/examples/haskell-miso.org/shared/Common.hs
+++ b/examples/haskell-miso.org/shared/Common.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE CPP                  #-}
 module Common where
 
 import           Data.Bool
@@ -10,6 +11,9 @@ import qualified Data.Map    as M
 import           Data.Monoid
 import           Data.Proxy
 import           Servant.API
+#if MIN_VERSION_servant(0,10,0)
+import Servant.Utils.Links
+#endif
 
 import           Miso
 import           Miso.String
@@ -325,11 +329,19 @@ the404 = template v
 -- | Links
 goHome, goExamples, goDocs, goCommunity :: URI
 ( goHome, goExamples, goDocs, goCommunity ) =
+#if MIN_VERSION_servant(0,10,0)
+    ( linkURI (safeLink routes homeProxy)
+    , linkURI (safeLink routes examplesProxy)
+    , linkURI (safeLink routes docsProxy)
+    , linkURI (safeLink routes communityProxy)
+    )
+#else
     ( safeLink routes homeProxy
     , safeLink routes examplesProxy
     , safeLink routes docsProxy
     , safeLink routes communityProxy
     )
+#endif
 
 homeProxy :: Proxy Home
 homeProxy = Proxy

--- a/examples/router/Main.hs
+++ b/examples/router/Main.hs
@@ -4,10 +4,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE CPP #-}
 module Main where
 
 import Data.Proxy
 import Servant.API
+#if MIN_VERSION_servant(0,10,0)
+import Servant.Utils.Links
+#endif
 
 import Miso
 
@@ -81,7 +85,11 @@ type About = "about" :> View Action
 goAbout, goHome :: Action
 (goHome, goAbout) = (goto api home, goto api about)
   where
+#if MIN_VERSION_servant(0,10,0)
+    goto a b = ChangeURI (linkURI (safeLink a b))
+#else
     goto a b = ChangeURI (safeLink a b)
+#endif
     home  = Proxy :: Proxy Home
     about = Proxy :: Proxy About
     api   = Proxy :: Proxy API

--- a/examples/sse/shared/Common.hs
+++ b/examples/sse/shared/Common.hs
@@ -1,8 +1,12 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 module Common where
 
 import Data.Proxy
 import Servant.API
+#if MIN_VERSION_servant(0,10,0)
+import Servant.Utils.Links
+#endif
 
 import Miso
 import Miso.String
@@ -38,4 +42,9 @@ the404 =
     ]
 
 goHome :: URI
-goHome = safeLink (Proxy :: Proxy ClientRoutes) (Proxy :: Proxy Home)
+goHome =
+#if MIN_VERSION_servant(0,10,0)
+  linkURI (safeLink (Proxy :: Proxy ClientRoutes) (Proxy :: Proxy Home))
+#else
+  safeLink (Proxy :: Proxy ClientRoutes) (Proxy :: Proxy Home)
+#endif


### PR DESCRIPTION
These fixes are necessary for servant >= 0.10 and >= 0.11. The
alternative to the CPP would be to just drop support for servant <
0.11 but since until recently servant-0.9 was still the version in
stackage LTS (all snapshots < LTS 9.0), I think it makes sense to
support it a bit longer. nixpkgs unstable has also moved to servant-0.11.