### PR TITLE
Async effects

### DIFF
--- a/ghcjs-src/Miso.hs
+++ b/ghcjs-src/Miso.hs
@@ -87,7 +87,7 @@ common App {..} m getView = do
                 foldl' (foldEffects writeEvent update)
                   (oldModel, pure ()) actions
           in (newModel, (oldModel /= newModel, effects))
-        effects
+        void $ forkIO effects
         pure (S.empty, shouldDraw)
     when shouldDraw $ do
       newVTree <-

--- a/ghcjs-src/Miso.hs
+++ b/ghcjs-src/Miso.hs
@@ -54,7 +54,7 @@ common App {..} m getView = do
   -- init Notifier
   Notify {..} <- newNotify
   -- init EventWriter
-  EventWriter {..} <- newEventWriter notify
+  EventWriter {..} <- newEventWriter
   -- init empty Model
   modelRef <- newIORef m
   -- init empty actions
@@ -65,8 +65,9 @@ common App {..} m getView = do
   -- init event application thread
   void . forkIO . forever $ do
     action <- getEvent
-    modifyMVar_ actionsMVar $! \actions ->
+    modifyMVar_ actionsMVar $! \actions -> do
       pure (actions |> action)
+    notify
   -- Hack to get around `BlockedIndefinitelyOnMVar` exception
   -- that occurs when no event handlers are present on a template
   -- and `notify` is no longer in scope

--- a/src/Miso/Concurrent.hs
+++ b/src/Miso/Concurrent.hs
@@ -26,15 +26,14 @@ data EventWriter action = EventWriter {
   }
 
 -- | Creates a new `EventWriter`
-newEventWriter :: IO () -> IO (EventWriter m)
-newEventWriter notify' = do
+newEventWriter :: IO (EventWriter m)
+newEventWriter = do
   chan <- newBoundedChan 50
   pure $ EventWriter (write chan) (readChan chan)
     where
       write chan event =
         void . forkIO $ do
           void $ tryWriteChan chan $! event
-          notify'
 
 -- | Concurrent API for `SkipChan` implementation
 data Notify = Notify {


### PR DESCRIPTION
This PR performs twofold:
  - Ensures we notify the redrawer only when we are certain an action exists. Fixing #255  
  - Evaluates effects asynchronously. Previously, evaluating accumulated `effects` was blocking redrawing.

cc @cocreature @FPtje