### PR TITLE
Added more info to URI returned by getCurrentURI

### DIFF
--- a/ghcjs-src/Miso/Subscription/History.hs
+++ b/ghcjs-src/Miso/Subscription/History.hs
@@ -41,11 +41,11 @@ getCurrentURI = getURI
 getURI :: IO URI
 {-# INLINE getURI #-}
 getURI = do
-  URI <$> pure mempty
+  URI <$> do unpack <$> getProtocol
       <*> pure Nothing
       <*> do Prelude.drop 1 . unpack <$> getPathName
       <*> do unpack <$> getSearch
-      <*> pure mempty
+      <*> do unpack <$> getHash
 
 -- | Pushes a new URI onto the History stack
 pushURI :: URI -> IO ()
@@ -106,6 +106,12 @@ foreign import javascript unsafe "$r = window.location.pathname;"
 
 foreign import javascript unsafe "$r = window.location.search;"
   getSearch :: IO JSString
+
+foreign import javascript unsafe "$r = window.location.hash;"
+  getHash :: IO JSString
+
+foreign import javascript unsafe "$r = window.location.protocol;"
+  getProtocol :: IO JSString
 
 foreign import javascript unsafe "window.addEventListener('popstate', $1);"
   onPopState :: Callback (IO ()) -> IO ()


### PR DESCRIPTION
# Motivation
I needed the URL fragment in the app I'm building. Found out they were missing 🍜

# Technical details
This PR fills in `uriScheme` and `uriFragment`

They were set to empty strings, but they can easily be retrieved from `window.location`, like `uriQuery` and `uriPath` are.

Two notes:

- I didn't touch `uriAuthority`, because I'm not sure how to construct it.
- The value filled in for `uriPath` strips the first `/` character, which seems to oppose the Haddock of [URI](http://hoogle.lumi.guide.local/file/nix/store/qw0lvqkyl0gicmhdwmfc26ari8dyqdg3-network-uri-2.6.1.0/share/doc/x86_64-linux-ghc-8.0.2/network-uri-2.6.1.0/html/Network-URI.html#t:URI). I didn't touch this because I have a gut feeling that there's a really good reason for this.