### PR TITLE
jsvalToValue

### DIFF
--- a/miso-ghcjs.nix
+++ b/miso-ghcjs.nix
@@ -1,7 +1,7 @@
 { mkDerivation, aeson, base, bytestring, containers, ghcjs-base
 , network-uri, scientific, stdenv, text, transformers
 , unordered-containers, vector, hspec, hspec-core, servant
-, http-types, http-api-data
+, http-types, http-api-data, QuickCheck, quickcheck-instances
 }:
 mkDerivation {
   pname = "miso";
@@ -12,7 +12,7 @@ mkDerivation {
   libraryHaskellDepends = [
     aeson base bytestring containers ghcjs-base network-uri scientific
     text transformers unordered-containers vector hspec hspec-core servant
-    http-types http-api-data
+    http-types http-api-data QuickCheck quickcheck-instances
   ];
   homepage = "http://github.com/dmjio/miso";
   description = "A tasty Haskell front-end framework";

--- a/miso.cabal
+++ b/miso.cabal
@@ -220,14 +220,29 @@ executable tests
     buildable: False
   else
     hs-source-dirs:
-      tests
+      tests, ghcjs-src, src
+    other-modules:
+      Miso.FFI
     build-depends:
       aeson,
       base < 5,
-      miso,
+      bytestring,
       hspec,
       hspec-core,
-      ghcjs-base
+      ghcjs-base,
+      QuickCheck,
+      quickcheck-instances,
+      miso,
+      http-types,
+      network-uri,
+      http-api-data,
+      containers,
+      scientific,
+      servant,
+      text,
+      unordered-containers,
+      transformers,
+      vector
     default-language:
       Haskell2010
 

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -1,15 +1,54 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE NamedFieldPuns #-}
-
-
 module Main where
 
-import Test.Hspec (it, hspec, describe, shouldSatisfy, shouldBe, Spec)
-import Test.Hspec.Core.Runner (hspecResult, Summary(..))
-import Data.Aeson
+import           Control.Monad
+import           Data.Aeson
+import qualified Data.HashMap.Strict       as H
+import           Data.Scientific
+import qualified Data.Vector               as V
+import           Debug.Trace
+import           GHCJS.Marshal
+import           Test.Hspec                (it, hspec, describe, shouldSatisfy, shouldBe, Spec)
+import           Test.Hspec.Core.Runner    (hspecResult, Summary(..))
+import           Test.QuickCheck
+import           Test.QuickCheck.Instances
 
-import Miso
+import           Miso
+import           Miso.FFI
+import           System.IO.Unsafe
+
+instance Arbitrary Value where
+  arbitrary = sized sizedArbitraryValue
+
+sizedArbitraryValue :: Int -> Gen Value
+sizedArbitraryValue n
+  | n <= 0 = oneof [pure Null, bool, number, string]
+  | otherwise = resize n' $ oneof [pure Null, bool, string, number, array, object']
+  where
+    n' = n `div` 2
+    bool = Bool <$> arbitrary
+    number = Number <$> arbitrary
+    string = String <$> arbitrary
+    array = Array <$> arbitrary
+    object' = Object <$> arbitrary
+
+compareValue :: Value -> Value -> Bool
+compareValue (Object x) (Object y) = and $ zipWith compareValue (H.elems x) (H.elems y)
+compareValue (Array x) (Array y)   = and $ zipWith compareValue (V.toList x) (V.toList y)
+compareValue (String x) (String y) = x == y
+compareValue (Bool x) (Bool y)     = x == y
+compareValue Null Null             = True
+compareValue (Number x) (Number y) = closeEnough x y
+compareValue _ _ = False
+
+closeEnough x y
+  = let d = max (abs x) (abs y)
+        relDiff = if (d == 0.0) then d else abs (x - y) / d
+    in relDiff <= 0.00001
 
 main :: IO ()
 main = do
@@ -19,6 +58,7 @@ main = do
 tests :: Spec
 tests = do
   storageTests
+  roundTripJSVal
 
 storageTests :: Spec
 storageTests = describe "Storage tests" $ do
@@ -32,6 +72,13 @@ storageTests = describe "Storage tests" $ do
     setSessionStorage "foo" obj
     Right r <- getLocalStorage "foo"
     r `shouldBe` obj
+
+roundTripJSVal =
+ describe "Serialization tests" $ do
+  it "Should round trip JSVal" $ do
+    property $ (\(x :: Value) -> do
+      Just y <- jsvalToValue =<< toJSVal x
+      compareValue x y `shouldBe` True)
 
 phantomExit :: Int -> IO ()
 phantomExit x


### PR DESCRIPTION
Fix `jsvalToValue` function. Allow for correct parsing of json between Haskell and JavaScript. 