### PR TITLE
Introduce the Transition monad

### DIFF
--- a/miso.cabal
+++ b/miso.cabal
@@ -277,7 +277,8 @@ library
     bytestring,
     containers,
     servant,
-    text
+    text,
+    transformers
   if impl(ghcjs)
     hs-source-dirs:
       ghcjs-src


### PR DESCRIPTION
This monad is useful for succinctly expressing model transitions. We use it a lot at LumiGuide. It's especially useful when used in combination with the stateful [lens operators](http://hackage.haskell.org/package/lens-4.15.4/docs/Control-Lens-Operators.html) (all operators ending in "`=`").

@FPtje I removed our `TransitionM` type synonym because I think it adds to much noise.