### PR TITLE
remove redundant calls to notify

### DIFF
--- a/ghcjs-src/Miso/Subscription/History.hs
+++ b/ghcjs-src/Miso/Subscription/History.hs
@@ -50,7 +50,7 @@ getURI = do
 -- | Pushes a new URI onto the History stack
 pushURI :: URI -> IO ()
 {-# INLINE pushURI #-}
-pushURI uri = pushStateNoModel uri { uriPath = path } >> notify chan
+pushURI uri = pushStateNoModel uri { uriPath = path }
   where
     path | uriPath uri == mempty = "/"
          | otherwise = uriPath uri
@@ -58,7 +58,7 @@ pushURI uri = pushStateNoModel uri { uriPath = path } >> notify chan
 -- | Replaces current URI on stack
 replaceURI :: URI -> IO ()
 {-# INLINE replaceURI #-}
-replaceURI uri = replaceTo' uri { uriPath = path } >> notify chan
+replaceURI uri = replaceTo' uri { uriPath = path }
   where
     path | uriPath uri == mempty = "/"
          | otherwise = uriPath uri


### PR DESCRIPTION
`pushStateNoModel` and `replaceTo'` respectively each call `notify chan` as their last step, so there's no need to call `notify chan` a second time when they are called in `pushURI` and `replaceURI`.