### PR TITLE
Reexport Miso.Router from the top-level Miso module

### DIFF
--- a/ghc-src/Miso.hs
+++ b/ghc-src/Miso.hs
@@ -15,9 +15,11 @@
 module Miso
   ( module Miso.Event
   , module Miso.Html
+  , module Miso.Router
   , module Miso.TypeLevel
   ) where
 
 import           Miso.Event
 import           Miso.Html
+import           Miso.Router
 import           Miso.TypeLevel


### PR DESCRIPTION
This is a follow up to #301. Since it’s reexported on `ghcjs` it makes sense to reexport it on `ghc` as well.